### PR TITLE
Fixes rounding issue with temperature value

### DIFF
--- a/src/mpu6050.c
+++ b/src/mpu6050.c
@@ -202,7 +202,7 @@ bool mpu6050_read_temperature(double *temperature) {
   }
 
   int16_t t = mgos_i2c_read_reg_w(s_dev->i2c, s_dev->addr, REG_TEMP_OUT);
-  *temperature = (t / 340) + 36.53;
+  *temperature = (float) t / 340.0 + 36.53;
 
   return true;
 }


### PR DESCRIPTION
I'm not a strong C developer (at all!), but I was seeing strange values with the temperature sensor using this and I believe it's because of a rounding issue. Below you can see the "before" and "after".



**Before** (`*temperature = (t / 340) + 36.53;`)

```
[Feb 22 07:00:39.652] main.c:46               temperature=18.53
[Feb 22 07:00:40.652] main.c:46               temperature=19.53
[Feb 22 07:00:41.652] main.c:46               temperature=19.53
[Feb 22 07:00:42.652] main.c:46               temperature=18.53
[Feb 22 07:00:43.652] main.c:46               temperature=18.53
[Feb 22 07:00:44.652] main.c:46               temperature=18.53
[Feb 22 07:00:45.652] main.c:46               temperature=19.53
[Feb 22 07:00:46.652] main.c:46               temperature=19.53
[Feb 22 07:00:47.652] main.c:46               temperature=19.53
```

**After** (`*temperature = (float)t / 340.0 + 36.53;`)

```
[Feb 22 07:04:07.635] main.c:46               temperature=19.40
[Feb 22 07:04:08.635] main.c:46               temperature=19.45
[Feb 22 07:04:09.635] main.c:46               temperature=19.54
[Feb 22 07:04:10.635] main.c:46               temperature=19.40
[Feb 22 07:04:11.635] main.c:46               temperature=19.45
[Feb 22 07:04:12.635] main.c:46               temperature=19.49
[Feb 22 07:04:13.635] main.c:46               temperature=19.45
[Feb 22 07:04:14.635] main.c:46               temperature=19.49
```